### PR TITLE
replace Object.values

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,10 @@ const defaults = {
   stream: process.stderr,
 };
 
-const hasRunning = () => Object.values(sharedState).find((s) => s.isRunning);
+const hasRunning = () =>
+  Object.keys(sharedState)
+    .map((e) => sharedState[e])
+    .find((s) => s.isRunning);
 
 const $logUpdate = logUpdate.create(process.stderr, {
   showCursor: false,
@@ -143,8 +146,9 @@ export default class WebpackBarPlugin extends webpack.ProgressPlugin {
 
     const columns = this.options.stream.columns || 80;
 
-    const stateLines = _.sortBy(Object.keys(sharedState), (n) => n).map(
-      (name) => {
+    const stateLines = _
+      .sortBy(Object.keys(sharedState), (n) => n)
+      .map((name) => {
         const state = sharedState[name];
         const color = colorize(state.color);
 
@@ -166,8 +170,7 @@ export default class WebpackBarPlugin extends webpack.ProgressPlugin {
             ? chalk.grey(elipsesLeft(formatRequest(state.request), columns - 2))
             : ''
         }\n`;
-      }
-    );
+      });
 
     if (hasRunning()) {
       const title = chalk.underline.blue('Compiling');


### PR DESCRIPTION

This PR contains a:

- [ x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** 
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

the package.json claims this module will run in node 6.*, however the code users `Object.values` here: https://github.com/nuxt/webpackbar/blob/master/src/index.js#L32

this will cause builds to fail in node 6.* environments because `Object.values` is not supported.

### Additional Info

i didn't add any tests as the way to test this will require updating your circleci configurations to run tests in a node 6.* environment. i'm not familiar with the circle.yml and this could be added in a separate update