### PR TITLE
fix(v2): use object.keys for node <= 7 support

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,9 @@ const defaults = {
   stream: null,
 };
 
-const hasRunning = () => Object.values(sharedState).find((s) => s.isRunning);
+
+const hasRunning = () =>Object.keys(sharedState).map(k=>sharedState[k]) .find(s => s.isRunning);
+
 
 const $logUpdate = logUpdate.create(process.stderr, {
   showCursor: false,


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [x] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case
to use Object.values your Node versions should be >= 7.0.0 , so i used keys and map..


