### PR TITLE
Patched write works even after stop listen

### DIFF
--- a/src/utils/log-update.js
+++ b/src/utils/log-update.js
@@ -74,8 +74,12 @@ export default class LogUpdate {
 
     for (const stream of this._streams) {
       if (!stream.__write) {
+        const s = stream;
         stream.__write = stream.write;
         stream.write = function write(data, ...args) {
+          if (!this.__write) {
+            return s.write(data, ...args);
+          }
           t._onData(data);
           this.__write(data, ...args);
         };


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [x] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

Fixes https://cmty.app/nuxt/webpackbar/issues/c31

Reduces (almost eliminates) the probability that the replacement of `stream.write` conflicts with other software doing this too.

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info
