### PR TITLE
fix: path can be something else than a string

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -39,7 +39,7 @@ export function range(len) {
 
 export function shortenPath(path = '') {
   const cwd = process.cwd() + sep;
-  return path.replace(cwd, '');
+  return String(path).replace(cwd, '');
 }
 
 export function objectValues(obj) {


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Fixing issue #43 (I also encountered).
It seems that sometime `path` is not a string (but is a number instead).
I don't know what are the cases and how to reproduce it, but it happens.

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->