### PR TITLE
Fix counting extra lines when lines wrap

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "ansis": "^3.17.0",
     "consola": "^3.4.2",
     "pretty-time": "^1.1.0",
-    "std-env": "^3.8.1"
+    "std-env": "^3.8.1",
+    "string-width": "^7.2.0"
   },
   "devDependencies": {
     "@babel/standalone": "^7.26.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       std-env:
         specifier: ^3.8.1
         version: 3.8.1
+      string-width:
+        specifier: ^7.2.0
+        version: 7.2.0
     devDependencies:
       '@babel/standalone':
         specifier: ^7.26.10


### PR DESCRIPTION
Fixes #164 

Previously, extra lines were counted only by the number of line breaks in them, so the number of lines cleared would be incorrect if any lines wrapped. Additionally, prevLineCount could be wrong if the size of the terminal changes between renders.

To fix this, the number of lines to clear is calculated immediately before clearing them, and the 'string-width' library is used to determine accurate widths and line counts. This is the same library used by 'wrap-ansi', so it should be reliable, and it is not actually a new dependency.

<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->
