### PR TITLE
chore(deps): correct upgrade dependency ansis to v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "test": "pnpm lint && vitest run"
   },
   "dependencies": {
-    "ansis": "^3.17.0",
+    "ansis": "^4.0.0",
     "consola": "^3.4.2",
     "pretty-time": "^1.1.0",
     "std-env": "^3.8.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       ansis:
-        specifier: ^3.17.0
-        version: 3.17.0
+        specifier: ^4.0.0
+        version: 4.0.0
       consola:
         specifier: ^3.4.2
         version: 3.4.2
@@ -1347,8 +1347,8 @@ packages:
     resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
     engines: {node: '>=12'}
 
-  ansis@3.17.0:
-    resolution: {integrity: sha512-0qWUglt9JEqLFr3w1I1pbrChn1grhaiAR2ocX1PP/flRmxgtwTzPFFFnfIlD6aMOLQZgSuCRlidD70lvx8yhzg==}
+  ansis@4.0.0:
+    resolution: {integrity: sha512-P8nrHI1EyW9OfBt1X7hMSwGN2vwRuqHSKJAT1gbLWZRzDa24oHjYwGHvEgHeBepupzk878yS/HBZ0NMPYtbolw==}
     engines: {node: '>=14'}
 
   anymatch@3.1.3:
@@ -4834,7 +4834,7 @@ snapshots:
 
   ansi-styles@6.2.1: {}
 
-  ansis@3.17.0: {}
+  ansis@4.0.0: {}
 
   anymatch@3.1.3:
     dependencies:

--- a/src/reporters/fancy.ts
+++ b/src/reporters/fancy.ts
@@ -1,4 +1,4 @@
-import { grey } from "ansis";
+import { gray } from "ansis";
 import { renderBar, colorize, ellipsisLeft } from "../utils/cli";
 import { formatRequest } from "../utils/webpack";
 import { BULLET, TICK, CROSS, CIRCLE_OPEN } from "../utils/consts";
@@ -52,13 +52,13 @@ export default class FancyReporter implements Reporter {
         renderBar(state.progress, state.color),
         state.message,
         `(${state.progress || 0}%)`,
-        grey(state.details[0] || ""),
-        grey(state.details[1] || ""),
+        gray(state.details[0] || ""),
+        gray(state.details[1] || ""),
       ].join(" ");
 
       line2 = state.request
         ? " " +
-          grey(ellipsisLeft(formatRequest(state.request), logUpdate.columns))
+          gray(ellipsisLeft(formatRequest(state.request), logUpdate.columns))
         : "";
     } else {
       let icon = " ";
@@ -72,7 +72,7 @@ export default class FancyReporter implements Reporter {
       }
 
       line1 = color(`${icon} ${state.name}`);
-      line2 = grey("  " + state.message);
+      line2 = gray("  " + state.message);
     }
 
     return line1 + "\n" + line2;


### PR DESCRIPTION
This is correct PR to upgrade dependency ansis to v4.

PR #166, created by `renovate bot`, should be closed without merging, as the major version update to v4 requires additional changes.