### PR TITLE
Fix counting extra lines when lines wrap

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "ansis": "^3.17.0",
     "consola": "^3.4.2",
     "pretty-time": "^1.1.0",
-    "std-env": "^3.8.1"
+    "std-env": "^3.8.1",
+    "string-width": "^7.2.0"
   },
   "devDependencies": {
     "@babel/standalone": "^7.26.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       std-env:
         specifier: ^3.8.1
         version: 3.8.1
+      string-width:
+        specifier: ^7.2.0
+        version: 7.2.0
     devDependencies:
       '@babel/standalone':
         specifier: ^7.26.10

--- a/src/utils/log-update.ts
+++ b/src/utils/log-update.ts
@@ -1,3 +1,4 @@
+import stringWidth from "string-width";
 import wrapAnsi from "wrap-ansi";
 import { eraseLines } from "./cli";
 
@@ -6,13 +7,13 @@ import { eraseLines } from "./cli";
 const originalWrite = Symbol("webpackbarWrite");
 
 export default class LogUpdate {
-  private prevLineCount: any;
-  private listening: any;
-  private extraLines: any;
-  private _streams: any;
+  private prevLines: string | null;
+  private listening: boolean;
+  private extraLines: string;
+  private _streams: NodeJS.WriteStream[];
 
   constructor() {
-    this.prevLineCount = 0;
+    this.prevLines = null;
     this.listening = false;
     this.extraLines = "";
     this._onData = this._onData.bind(this);
@@ -29,17 +30,30 @@ export default class LogUpdate {
     });
 
     const data =
-      eraseLines(this.prevLineCount) + wrappedLines + "\n" + this.extraLines;
+      eraseLines(this.lineCount) + wrappedLines + "\n" + this.extraLines;
 
     this.write(data);
+    this.prevLines = data;
+  }
 
-    const _lines = data.split("\n");
-    this.prevLineCount = _lines.length;
+  /**
+   * The number of lines currently rendered, based on this.prevLines and the
+   * terminal width. Since the terminal can be resized at any time, this value
+   * should be retrieved immediately before erasing to get an accurate count.
+   */
+  get lineCount() {
+    if (this.prevLines === null) {
+      return 0;
+    }
 
-    // Count wrapped line too
-    // https://github.com/unjs/webpackbar/pull/90
-    // TODO: Count length with regards of control chars
-    // this.prevLineCount += _lines.reduce((s, l) => s + Math.floor(l.length / this.columns), 0)
+    const splitLines = this.prevLines.split("\n");
+    let lineCount = 0;
+    for (const line of splitLines) {
+      // Use stringWidth to only count printed characters
+      const lineWidth = stringWidth(line);
+      lineCount += Math.max(1, Math.ceil(lineWidth / this.columns));
+    }
+    return lineCount;
   }
 
   get columns() {
@@ -56,14 +70,14 @@ export default class LogUpdate {
   }
 
   clear() {
+    this.write(eraseLines(this.lineCount));
     this.done();
-    this.write(eraseLines(this.prevLineCount));
   }
 
   done() {
     this.stopListen();
 
-    this.prevLineCount = 0;
+    this.prevLines = null;
     this.extraLines = "";
   }
 
@@ -71,7 +85,7 @@ export default class LogUpdate {
     const str = String(data);
     const lines = str.split("\n").length - 1;
     if (lines > 0) {
-      this.prevLineCount += lines;
+      this.prevLines = (this.prevLines ?? "") + data;
       this.extraLines += data;
     }
   }


### PR DESCRIPTION
(note: this PR was originally submitted as #165, but I needed to change the source branch, so I am re-creating it)



Fixes #164 

Previously, extra lines were counted only by the number of line breaks in them, so the number of lines cleared would be incorrect if any lines wrapped. Additionally, prevLineCount could be wrong if the size of the terminal changes between renders.

To fix this, the number of lines to clear is calculated immediately before clearing them, and the 'string-width' library is used to determine accurate widths and line counts. This is the same library used by 'wrap-ansi', so it should be reliable, and it is not actually a new dependency.


<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reworked terminal log rendering to track previously rendered output more precisely, improving behavior across updates and terminal resizing.
* **Bug Fixes**
  * Fixed occasional line misalignment or incorrect clearing/erasing when output contains wide characters (e.g., full-width text) or when the terminal dimensions change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->